### PR TITLE
Feature: "typeless" parcel items

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "rules": {
       "brace-style": "off",
       "class-methods-use-this": "off",
-      "comma-dangle": ["error", "never"],
+      "comma-dangle": ["off", "never"],
       "@typescript-eslint/brace-style": "off",
       "@typescript-eslint/comma-dangle": ["error", "never"],
       "@typescript-eslint/indent": "off",

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ If you would like to see a system added, please open an [issue](https://github.c
 ```
 $parcel
 ```
-3. Add more lines, one line per item in the parcel:
+3. Add links of items to the parcel, one per line:
 ```
-$cypher @UUID[...]{Detonation} l=1d6
-$armor @UUID[...]{Leather jerkin} q=4
+@UUID[...]{Detonation} l=1d6
+@UUID[...]{Leather jerkin} q=4
 ```
 4. Drag the journal page onto an actor to give them the loot!
 
@@ -44,16 +44,18 @@ $armor @UUID[...]{Leather jerkin} q=4
 
 ```
 $parcel
-$currency shins 1d6
-$armor @UUID[]{Leather jerkin}
-$weapon @UUID[]{Light sword} q=1d3
-$cypher @UUID[Compendium.world.cyphers.abc123]{A really cool cypher} l=1d6
-$parts 1d10
+shins 1d6 t=currency
+@UUID[]{Leather jerkin}
+@UUID[]{Light sword} q=1d3
+@UUID[Compendium.world.cyphers.abc123]{A really cool cypher} l=1d6
+parts 1d10
 ```
 
 ## Documentation
 
-### Directives
+### Breakdown of a parcel item
+
+TODO
 
 Directives are the first part of each line in a parcel, indicating what type of item is in the parcel.
 A directive begins with a `$` (you know, for loot).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Create parcels of loot to hand out to the PCs
 
 The following systems are currently supported:
 
-* Advanced 5E (Level Up) [pending]
-* Black Flag Roleplaying [pending]
+* Advanced 5E (Level Up)
+* Black Flag Roleplaying
 * Cypher System
 * Dungeons & Dragons, 5th edition
 * Genesys
@@ -44,21 +44,72 @@ $parcel
 
 ```
 $parcel
-shins 1d6 t=currency
-@UUID[]{Leather jerkin}
-@UUID[]{Light sword} q=1d3
-@UUID[Compendium.world.cyphers.abc123]{A really cool cypher} l=1d6
-parts 1d10
+$currency shins q=1d6
+@UUID[...]{Leather jerkin}
+@UUID[...]{Light sword} q=1d3
+@UUID[...]{A really cool cypher} l=1d6
+Parts q=1d10
 ```
 
 ## Documentation
 
 ### Breakdown of a parcel item
 
-TODO
+Each line of the journal that is marked as parcel contains an item. There are three different ways to
+specify the item, which are covered here.
 
-Directives are the first part of each line in a parcel, indicating what type of item is in the parcel.
-A directive begins with a `$` (you know, for loot).
+#### Item link
+
+An item link entry will look something like this:
+
+```
+@UUID[...]{Light sword} q=1d3
+```
+
+This type of entry is the recommended way of populating your parcels. Item links mean that all the item
+data can be copied to the actor.
+
+#### Free text
+
+A free text entry will look something like this:
+
+```
+Parts q=1d10
+```
+
+This type of entry allows you to create ad-hoc items on the actor. No lookup is performed, so you don't get
+any information about the item, because this type of entry only knows the item's name. The module will
+attempt to do the right thing in creating the item. You can provide modifiers (see below) to influence
+or coerce how the item is created.
+
+#### Directive
+
+A directive is a text token that starts with the character `$` and is followed immediately by alphanumeric
+characters with no spaces. A directive entry will look something like this:
+
+```
+$currency gp q=1d100
+```
+
+There is a common directive that works for most game systems, but for the most part, using Loot Parcels in a
+particular system may enable other directives (see below).
+
+#### Modifiers
+
+Parcel items can also include zero or more optional modifiers, in the form of key/value pairs separated by an
+equal sign (`=`), for example, `q=3`. The currently supported modifiers are described below.
+
+| Modifier | Value | Description |
+| - | - | - |
+| `quantity` or `q` | `number` or die spec | Specifies a quantity for the parcel item. If omitted, the quantity defaults to 1. Supports using a die spec. |
+| `level` or `l` | `number` or die spec | Indicates the level of the parcel item. If omitted, the level defaults to 1. Supports using a die spec. |
+| `type` | any | Allows you to specify the type of a parcel item. This is usually needed when using the free text form. |
+| `stacked` | `boolean` | Specifies that you want the item added to the actor by stacking with any existing items of the same name instead of creating a new instance. |
+
+### Directives
+
+When using the directive form of a parcel item entry, the directive is the first part of each line in a parcel.
+A directive begins with a `$`.
 
 Some directives support additional arguments. An optional argument is enclosed in square brackets, like `[this]`,
 whereas a required argument is enclosed in angle brackets, like `<this>`. Arguments are explained in the
@@ -66,37 +117,4 @@ description for the directive.
 
 | Directive | Arguments | System | Description |
 | - | - | - | - |
-| `$parcel` | None | All | Marks the journal page as a loot parcel |
-| `$currency` | `[name] <quantity>` | All | This is for money. The `name` is the type of currency, if the system supports more than one kind. If omitted, the default currency for the system is used. `quantity` indicates the amount. |
-| `$armor` | `<link>` | All | Armor or shields. |
-| `$weapon` | `<link>` | All | A weapon. |
-| `$equipment` or `$item` or `$gear` | `<link>` | All | A piece of gear. |
-| `$loot` | `<link>` | D&D5e, A5e | Miscellaneous items, like trinkets. |
-| `$tool` | `<link>` | D&D5e, A5e | Tools and items use to support other activities. |
-| `$container` | `<link>` | D&D5e, A5e | Something that can hold other items. |
-| `$consumable` | `<link>` | D&D5e, A5e, The One Ring | Anything that can be used up, like ammo, potions, scrolls, etc. |
-| `$ammo` or `$ammunition` | `<link>` | Shadow of the Demon Lord | Stuff for your weapon. |
-| `$iotum` | `<link>` | Cypher System | A specific type of iotum. |
-| `$parts` | `<quantity>` | Cypher System | A quantity of parts. |
-| `$cypher` | `<link>` | Cypher System | A cypher. |
-| `$artifact` | `<link>` | Cypher System | An artifact. |
-
-As a best practice, use a link (it looks something like `@UUID[<id>]{name}` in the editor)
-for the parcel item instead of a plain text name. Using a link allows Loot Parcels to copy all relevant information about the
-item to the character when the parcel is dropped on them. If you use text, the mod will do its best to create the
-appropriate item on the character, but it usually won't have all the useful information that you want.
-
-Where `quantity` is used, either in an argument or modifier (see below), a die spec can be provided to generate
-a random amount of that item. It's worth noting that some items you want to have stacked (i.e., if the character already
-has a quantity of the item, you just want the quantity to increase) as opposed to creating a new entry on the Actor
-sheet. For some systems, this is the difference between using `$item` and `$consumable`. And some systems do not support
-`$ammo`, so you probably want to use `$consumable` instead.
-
-Parcel items can also include zero or more optional modifiers, in the form of key/value pairs separated by an
-equal sign (`=`), for example, `q=3`. The currently supported modifiers are described below.
-
-| Modifier | Description |
-| - | - |
-| `q` | Specifies a quantity for the parcel item. If omitted, the quantity defaults to 1. |
-| `l` | Indicates the level of the parcel item. If omitted, the level defaults to 1. |
-| `t` | Allows you to specify a sub-type of a parcel item. |
+| `$currency` | `<name>` | All | This is for money. The `name` is the type of currency. To specify quantity, use the `q` modifier. |

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,7 @@
 {
     "LOOTPARCELS.UnsupportedJournalType": "The journal {name}'s type ({type}) is not recognized by Loot Parcels.",
-    "LOOTPARCELS.UnsupportedLootType": "The loot item {name} is not recognized by Loot Parcels.",
+    "LOOTPARCELS.UnsupportedParcelType": "The loot item {name} is not recognized by Loot Parcels.",
     "LOOTPARCELS.MissingArguments": "The loot item {name} does not have enough arguments: {args}.",
-    "LOOTPARCELS.InvalidArgument": "The loot item '{name}' argument '{value}' is invalid."
+    "LOOTPARCELS.InvalidArgument": "The loot item '{name}' argument '{value}' is invalid.",
+    "LOOTPARCELS.Parts": "Parts"
 }

--- a/loot-parcels.js
+++ b/loot-parcels.js
@@ -1,5 +1,3 @@
-// 'use strict';
-
 import { Config } from "./scripts/config.js";
 // import { Utils } from "./scripts/utilities.js";
 import { handleParcelDrop } from "./scripts/parcels.js";
@@ -76,7 +74,7 @@ Hooks.once('setup', async () => {
 			TOR2eSystem.registerHandlers();
 			break;
 		case 'tor1e':
-			Registry.registerAcceptableActorTypes(['TBD']);
+			Registry.registerAcceptableActorTypes(['character']);
 			TOR1eSystem.registerHandlers();
 			break;
 		case 'shadowdark':
@@ -93,36 +91,36 @@ Hooks.once('setup', async () => {
 			break;
 	}
 
-	Logging.info('Setting up socket...');
-	game.socket.on(`module.${Config.MODULE.NAME}`, packet => {
-		Logging.debug(packet);
+	// Logging.info('Setting up socket...');
+	// game.socket.on(`module.${Config.MODULE.NAME}`, packet => {
+	// 	Logging.debug(packet);
 
-		let data = packet.data;
-		data.receiver = game.actors.get(packet.receiverId);
-		data.trader = game.actors.get(packet.traderId);
-		data.traderUserId = packet.traderUserId;
-		// switch (packet.type) {
-		// 	case 'requestTrade':
-		// 		if (packet.traderUserId != game.user.id &&
-		// 			data.receiver.isOwner &&
-		// 			(!game.user.isGM ||
-		// 				!data.receiver.hasPlayerOwner)) {
-		// 					receiveTrade(data, packet.traderUserId);
-		// 				}
-		// 		break;
-		// 	case 'acceptTrade':
-		// 		if (packet.traderUserId == game.user.id) {
-		// 			endTrade(data)
-		// 		};
-		// 		break;
-		// 	case 'refuseTrade':
-		// 		if (packet.traderUserId == game.user.id) denyTrade(data);
-		// 		break;
-		// 	case 'possessItem':
-		// 		if (packet.traderUserId == game.user.id) alreadyTrade(data);
-		// 		break;
-		// }
-	});
+	// 	let data = packet.data;
+	// 	data.receiver = game.actors.get(packet.receiverId);
+	// 	data.trader = game.actors.get(packet.traderId);
+	// 	data.traderUserId = packet.traderUserId;
+	// 	// switch (packet.type) {
+	// 	// 	case 'requestTrade':
+	// 	// 		if (packet.traderUserId != game.user.id &&
+	// 	// 			data.receiver.isOwner &&
+	// 	// 			(!game.user.isGM ||
+	// 	// 				!data.receiver.hasPlayerOwner)) {
+	// 	// 					receiveTrade(data, packet.traderUserId);
+	// 	// 				}
+	// 	// 		break;
+	// 	// 	case 'acceptTrade':
+	// 	// 		if (packet.traderUserId == game.user.id) {
+	// 	// 			endTrade(data)
+	// 	// 		};
+	// 	// 		break;
+	// 	// 	case 'refuseTrade':
+	// 	// 		if (packet.traderUserId == game.user.id) denyTrade(data);
+	// 	// 		break;
+	// 	// 	case 'possessItem':
+	// 	// 		if (packet.traderUserId == game.user.id) alreadyTrade(data);
+	// 	// 		break;
+	// 	// }
+	// });
 });
 
 // Called when dropping something on the character sheet

--- a/module.json
+++ b/module.json
@@ -22,7 +22,6 @@
     "loot-parcels.js"
   ],
   "styles": [
-    "styles/loot-parcels.css"
   ],
   "languages": [
     {
@@ -32,7 +31,7 @@
       "flags": {}
     }
   ],
-  "socket": true,
+  "socket": false,
   "relationships": {
     "systems": [
       {

--- a/scripts/handlers-a5e.js
+++ b/scripts/handlers-a5e.js
@@ -1,64 +1,76 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class A5eSystem {
+
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        Registry.registerLootHandler('equipment', A5eSystem.handleEquipment);
-        Registry.registerLootHandler('item', A5eSystem.handleEquipment);
-        Registry.registerLootHandler('gear', A5eSystem.handleEquipment);
-        Registry.registerLootHandler('consumable', A5eSystem.handleConsumable);
-        Registry.registerLootHandler('container', A5eSystem.handleContainer);
-        Registry.registerLootHandler('loot', A5eSystem.handleLoot);
-        Registry.registerLootHandler('tool', A5eSystem.handleTool);
-        Registry.registerLootHandler('armor', A5eSystem.handleArmor);
-        Registry.registerLootHandler('weapon', A5eSystem.handleWeapon);
+        // Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerStackedItemCallback(A5eSystem._isItemStackable);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    static async _isItemStackable(item) {
+        Logging.debug("_isItemStackable", item);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
+        return (item.type == 'object' &&
+            (item.system.objectType == 'tool' ||
+                item.system.objectType == 'miscellaneous' ||
+            item.system.objectType == 'consumable'));
     }
 
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
+    // static async handleEquipment(actor, args) {
+    //     Logging.debug('handleEquipment', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
 
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleLoot(actor, args) {
-        Logging.debug('handleLoot', actor, args);
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'loot', args);
-    }
+    //     await AllSystems.handleItem(actor, 'weapon', args);
+    // }
 
-    static async handleTool(actor, args) {
-        Logging.debug('handleTool', actor, args);
+    // static async handleLoot(actor, args) {
+    //     Logging.debug('handleLoot', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'tool', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'loot', args);
+    // }
 
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
+    // static async handleTool(actor, args) {
+    //     Logging.debug('handleTool', actor, args);
 
-        await AllSystems.handleItem(actor, 'container', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'tool', args);
+    // }
 
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
+    // static async handleContainer(actor, args) {
+    //     Logging.debug('handleContainer', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
+    //     await AllSystems.handleItem(actor, 'container', args);
+    // }
+
+    // static async handleConsumable(actor, args) {
+    //     Logging.debug('handleConsumable', actor, args);
+
+    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
+    // }
 }

--- a/scripts/handlers-a5e.js
+++ b/scripts/handlers-a5e.js
@@ -23,7 +23,7 @@ export class A5eSystem {
         Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
     }
 
-    static async _isItemStackable(item) {
+    static _isItemStackable(item) {
         Logging.debug("_isItemStackable", item);
 
         return (item.type == 'object' &&

--- a/scripts/handlers-all.js
+++ b/scripts/handlers-all.js
@@ -13,8 +13,7 @@ export class AllSystems {
     static async handleItem(actor, type, args, addlSystemInfo) {
         Logging.debug('handleItem', actor, type, args, addlSystemInfo);
 
-        let itemName = args.name;
-        let itemDesc = "";
+        let itemName = args.name || args.text || "An item with no name";
         let itemLevel = args.level;
         let quantity = parseInt(args.quantity);
         let itemData = null;
@@ -29,8 +28,6 @@ export class AllSystems {
             if (item !== undefined && item !== null) {
                 itemName = item.name;
                 Logging.debug('itemName', itemName);
-                itemDesc = item.system.description || "";
-
                 itemData = item;
             }
             else {
@@ -51,7 +48,7 @@ export class AllSystems {
             if (type == null || type == '') {
                 type = args.type || 'item';
             }
-            const data = { name: itemName, type: type, system: addlSystemInfo || {}, description: { value: itemDesc } };
+            const data = { name: itemName, type: type, system: addlSystemInfo || {} };
             Logging.debug("data", data);
             const item = await Item.create([data], { parent: actor });
             Logging.debug("item", item);
@@ -61,8 +58,7 @@ export class AllSystems {
     static async handleStackedItem(actor, type, args, addlSystemInfo, qtyProp) {
         Logging.debug('handleStackedItem', actor, type, args, addlSystemInfo, qtyProp);
 
-        let itemName = args.name;
-        let itemDesc = "";
+        let itemName = args.name || args.text || "An item with no name";
         let itemLevel = args.level;
         let quantity = parseInt(args.quantity);
         let quantityProperty = qtyProp || 'system.quantity';
@@ -78,8 +74,6 @@ export class AllSystems {
             if (item !== undefined && item !== null) {
                 itemName = item.name;
                 Logging.debug('itemName', itemName);
-                itemDesc = item.system.description || "";
-
                 itemData = item;
             }
             else {
@@ -135,7 +129,7 @@ export class AllSystems {
         if (type == null || type == '') {
             type = args.type || 'item';
         }
-        const data = { name: itemName, type: type, system: addlSystemInfo || {}, description: { value: itemDesc } };
+        const data = { name: itemName, type: type, system: addlSystemInfo || {} };
         Logging.debug("data", data);
         const item = await Item.create([data], { parent: actor });
         Logging.debug("item", item);
@@ -155,20 +149,28 @@ export class AllSystems {
      * @param {*} actor
      * @param {*} args
      */
-    static async handleNamedCurrency(actor, args) {
-        Logging.debug('handleNamedCurrency', actor, args);
+    static async handleCurrency(actor, args) {
+        Logging.debug('handleCurrency', actor, args);
 
         let name = args.name;
         let quantity = args.quantity;
 
-        const currentAmount = actor.system.currency[name];
+        AllSystems.updateCurrency(actor, 'system.currency', name, quantity);
+    }
+
+    static async updateCurrency(actor, basePath, name, quantity) {
+        Logging.debug('updateCurrency', actor, basePath, name, quantity);
+
+        const fullPath = `${basePath}.${name}`;
+        Logging.debug('fullPath', fullPath);
+        const currentAmount = foundry.utils.getProperty(actor, fullPath);
         Logging.debug("currentAmount", currentAmount);
         const amount = parseInt(currentAmount) + parseInt(quantity);
         Logging.debug('amount', amount);
-        const updateAttr = `system.currency.${name}`;
         const data = {
-            [updateAttr]: amount,
+            [fullPath]: amount,
         };
+        Logging.debug('data', data);
         await actor.update(data);
     }
 }

--- a/scripts/handlers-all.js
+++ b/scripts/handlers-all.js
@@ -23,7 +23,7 @@ export class AllSystems {
         const stackedItemTypes = Registry.getStackedItemTypes();
         const stackedItemCallback = Registry.getStackedItemCallback();
         Logging.debug('stackedItemTypes', stackedItemTypes, "stackedItemCallback", stackedItemCallback);
-        const stacked = args.stacked || Utils.shouldStackItem(item, stackedItemTypes);
+        const stacked = args.stacked || Utils.shouldStackItem(item, stackedItemTypes, stackedItemCallback);
         const type = item.type;
         Logging.debug('type', type, 'stacked', stacked);
 

--- a/scripts/handlers-all.js
+++ b/scripts/handlers-all.js
@@ -1,12 +1,42 @@
-'use strict';
-
+/**
+ *
+ */
 import { Logging } from "./logging.js";
+import { Utils } from "./utilities.js";
+import { Registry } from "./registry.js";
 
+/**
+ *
+ */
 export class AllSystems {
 
     /**
      *
-     * @param {*} actor
+     * @param {Actor} actor
+     * @param {object} args
+     */
+    static async handleLinkEntry(actor, args) {
+        Logging.debug('handleLinkEntry', actor, args);
+
+        const item = await fromUuid(args.link.id);
+        Logging.debug('item', item);
+        const stackedItemTypes = Registry.getStackedItemTypes();
+        Logging.debug('stackedItemTypes', stackedItemTypes);
+        const stacked = args.stacked || Utils.shouldStackItem(item, stackedItemTypes);
+        const type = item.type;
+        Logging.debug('type', type, 'stacked', stacked);
+
+        if (stacked) {
+            await AllSystems.handleStackedItem(actor, type, args);
+        }
+        else {
+            await AllSystems.handleItem(actor, type, args);
+        }
+    }
+
+    /**
+     *
+     * @param {Actor} actor
      * @param {*} type
      * @param {*} args
      */
@@ -152,7 +182,7 @@ export class AllSystems {
     static async handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
-        let name = args.name;
+        let name = args.name || args.text || 'default';
         let quantity = args.quantity;
 
         AllSystems.updateCurrency(actor, 'system.currency', name, quantity);

--- a/scripts/handlers-all.js
+++ b/scripts/handlers-all.js
@@ -21,7 +21,8 @@ export class AllSystems {
         const item = await fromUuid(args.link.id);
         Logging.debug('item', item);
         const stackedItemTypes = Registry.getStackedItemTypes();
-        Logging.debug('stackedItemTypes', stackedItemTypes);
+        const stackedItemCallback = Registry.getStackedItemCallback();
+        Logging.debug('stackedItemTypes', stackedItemTypes, "stackedItemCallback", stackedItemCallback);
         const stacked = args.stacked || Utils.shouldStackItem(item, stackedItemTypes);
         const type = item.type;
         Logging.debug('type', type, 'stacked', stacked);

--- a/scripts/handlers-all.js
+++ b/scripts/handlers-all.js
@@ -37,6 +37,26 @@ export class AllSystems {
     /**
      *
      * @param {Actor} actor
+     * @param {object} args
+     */
+    static async handleTextEntry(actor, args) {
+        Logging.debug('handleTextEntry', actor, args);
+
+        const stacked = args.stacked || false;
+        const type = args.type || 'item';
+        Logging.debug('type', type, 'stacked', stacked);
+
+        if (stacked) {
+            await AllSystems.handleStackedItem(actor, type, args);
+        }
+        else {
+            await AllSystems.handleItem(actor, type, args);
+        }
+    }
+
+    /**
+     *
+     * @param {Actor} actor
      * @param {*} type
      * @param {*} args
      */
@@ -130,6 +150,7 @@ export class AllSystems {
                     await item.update(data);
                 }
                 catch (error) {
+                    Logging.debug("item.update threw error", error);
                     foundry.utils.setProperty(item, quantityProperty, newAmount);
                 }
                 return;
@@ -151,6 +172,7 @@ export class AllSystems {
                 await item.update(data);
             }
             catch (error) {
+                Logging.debug("item.update threw error", error);
                 foundry.utils.setProperty(item, quantityProperty, quantity);
             }
             return;

--- a/scripts/handlers-black-flag.js
+++ b/scripts/handlers-black-flag.js
@@ -1,64 +1,108 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class BlackFlagSystem {
+    static stackedItemTypes = ['consumable', 'ammunition', 'tool', 'gear', 'currency', 'sundry'];
+
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        Registry.registerLootHandler('equipment', BlackFlagSystem.handleEquipment);
-        Registry.registerLootHandler('item', BlackFlagSystem.handleEquipment);
-        Registry.registerLootHandler('gear', BlackFlagSystem.handleEquipment);
-        Registry.registerLootHandler('consumable', BlackFlagSystem.handleConsumable);
-        Registry.registerLootHandler('container', BlackFlagSystem.handleContainer);
-        Registry.registerLootHandler('loot', BlackFlagSystem.handleLoot);
-        Registry.registerLootHandler('tool', BlackFlagSystem.handleTool);
-        Registry.registerLootHandler('armor', BlackFlagSystem.handleArmor);
-        Registry.registerLootHandler('weapon', BlackFlagSystem.handleWeapon);
+        // Registry.registerStackedItemCallback(BlackFlagSystem._isItemStackable);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', BlackFlagSystem._handleCurrency);
+        // Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
+        // Registry.registerLootHandler('equipment', BlackFlagSystem.handleEquipment);
+        // Registry.registerLootHandler('item', BlackFlagSystem.handleEquipment);
+        // Registry.registerLootHandler('gear', BlackFlagSystem.handleEquipment);
+        // Registry.registerLootHandler('consumable', BlackFlagSystem.handleConsumable);
+        // Registry.registerLootHandler('container', BlackFlagSystem.handleContainer);
+        // Registry.registerLootHandler('loot', BlackFlagSystem.handleLoot);
+        // Registry.registerLootHandler('tool', BlackFlagSystem.handleTool);
+        // Registry.registerLootHandler('armor', BlackFlagSystem.handleArmor);
+        // Registry.registerLootHandler('weapon', BlackFlagSystem.handleWeapon);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    static async _handleCurrency(actor, args) {
+        Logging.debug('handleCurrency', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
+        const name = args.text?.toLowerCase() || 'gp';
+        Logging.debug('name', name);
+        const amount = args.quantity || 1;
+
+        const items = actor.collections.items.filter(i => i.system.identifier?.value == name);
+        Logging.debug('items', items);
+
+        if (items.length > 0) {
+            const currentAmount = parseInt(items[0].system.quantity);
+            Logging.debug("currentAmount", currentAmount);
+            const newAmount = currentAmount + amount;
+            Logging.debug("newAmount", newAmount);
+            const data = { system: { quantity: newAmount } };
+            Logging.debug("data", data);
+            await items[0].update(data);
+            return;
+        }
+
+        const localeKey = `LOOTPARCELS.Currency.${name}`;
+        let localizedName = game.i18n.localize(localeKey);
+        if(localizedName == localeKey) { localizedName = name; }
+        const data = { name: localizedName, type: 'currency', system: { identifier: { value: name }, quantity: amount } };
+        Logging.debug("data", data);
+        const newItem = await Item.create([data], { parent: actor });
+        Logging.debug("newItem", newItem);
     }
 
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
+    // static async handleEquipment(actor, args) {
+    //     Logging.debug('handleEquipment', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
 
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleLoot(actor, args) {
-        Logging.debug('handleLoot', actor, args);
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'loot', args);
-    }
+    //     await AllSystems.handleItem(actor, 'weapon', args);
+    // }
 
-    static async handleTool(actor, args) {
-        Logging.debug('handleTool', actor, args);
+    // static async handleLoot(actor, args) {
+    //     Logging.debug('handleLoot', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'tool', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'loot', args);
+    // }
 
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
+    // static async handleTool(actor, args) {
+    //     Logging.debug('handleTool', actor, args);
 
-        await AllSystems.handleItem(actor, 'container', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'tool', args);
+    // }
 
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
+    // static async handleContainer(actor, args) {
+    //     Logging.debug('handleContainer', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
+    //     await AllSystems.handleItem(actor, 'container', args);
+    // }
+
+    // static async handleConsumable(actor, args) {
+    //     Logging.debug('handleConsumable', actor, args);
+
+    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
+    // }
 }

--- a/scripts/handlers-black-flag.js
+++ b/scripts/handlers-black-flag.js
@@ -17,21 +17,10 @@ export class BlackFlagSystem {
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        // Registry.registerStackedItemCallback(BlackFlagSystem._isItemStackable);
         Registry.registerStackedItemTypes(this.stackedItemTypes);
         Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
         Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
         Registry.registerDirectiveHandler('currency', BlackFlagSystem._handleCurrency);
-        // Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        // Registry.registerLootHandler('equipment', BlackFlagSystem.handleEquipment);
-        // Registry.registerLootHandler('item', BlackFlagSystem.handleEquipment);
-        // Registry.registerLootHandler('gear', BlackFlagSystem.handleEquipment);
-        // Registry.registerLootHandler('consumable', BlackFlagSystem.handleConsumable);
-        // Registry.registerLootHandler('container', BlackFlagSystem.handleContainer);
-        // Registry.registerLootHandler('loot', BlackFlagSystem.handleLoot);
-        // Registry.registerLootHandler('tool', BlackFlagSystem.handleTool);
-        // Registry.registerLootHandler('armor', BlackFlagSystem.handleArmor);
-        // Registry.registerLootHandler('weapon', BlackFlagSystem.handleWeapon);
     }
 
     static async _handleCurrency(actor, args) {
@@ -64,45 +53,4 @@ export class BlackFlagSystem {
         Logging.debug("newItem", newItem);
     }
 
-    // static async handleEquipment(actor, args) {
-    //     Logging.debug('handleEquipment', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args);
-    // }
-
-    // static async handleArmor(actor, args) {
-    //     Logging.debug('handleArmor', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args);
-    // }
-
-    // static async handleWeapon(actor, args) {
-    //     Logging.debug('handleWeapon', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'weapon', args);
-    // }
-
-    // static async handleLoot(actor, args) {
-    //     Logging.debug('handleLoot', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'loot', args);
-    // }
-
-    // static async handleTool(actor, args) {
-    //     Logging.debug('handleTool', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'tool', args);
-    // }
-
-    // static async handleContainer(actor, args) {
-    //     Logging.debug('handleContainer', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'container', args);
-    // }
-
-    // static async handleConsumable(actor, args) {
-    //     Logging.debug('handleConsumable', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
-    // }
 }

--- a/scripts/handlers-cyphersystem.js
+++ b/scripts/handlers-cyphersystem.js
@@ -1,29 +1,34 @@
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ * Class container for all Cypher System related functions.
+ */
 export class CypherSystem {
     static stackedItemTypes = ['material'];
 
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
         Registry.registerLinkEntryHandler(CypherSystem._handleLinkEntry);
         Registry.registerTextEntryHandler(CypherSystem._handleTextEntry);
         Registry.registerDirectiveHandler('currency', CypherSystem._handleCurrency);
-        // Registry.registerLootHandler('currency', CypherSystem.handleCurrency);
         Registry.registerDirectiveHandler('parts', CypherSystem._handleParts);
         Registry.registerDirectiveHandler('iotum', CypherSystem._handleIotum);
-        // Registry.registerLootHandler('equipment', CypherSystem.handleEquipment);
-        // Registry.registerLootHandler('item', CypherSystem.handleEquipment);
-        // Registry.registerLootHandler('gear', CypherSystem.handleEquipment);
-        // Registry.registerLootHandler('armor', CypherSystem.handleArmor);
-        // Registry.registerLootHandler('weapon', CypherSystem.handleWeapon);
-        // Registry.registerLootHandler('cypher', CypherSystem.handleCypher);
-        // Registry.registerLootHandler('artifact', CypherSystem.handleArtifact);
     }
 
+    /**
+     *
+     * @param {CypherItem} item
+     * @returns
+     */
     static _shouldStackItem(item) {
         Logging.debug('_shouldStackItem', item);
 
@@ -34,6 +39,11 @@ export class CypherSystem {
         return false;
     }
 
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
     static async _handleLinkEntry(actor, args) {
         Logging.debug('_handleLinkEntry', actor, args);
 
@@ -58,6 +68,11 @@ export class CypherSystem {
         }
     }
 
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
     static async _handleTextEntry(actor, args) {
         Logging.debug('_handleTextEntry', actor, args);
 
@@ -80,133 +95,41 @@ export class CypherSystem {
         }
     }
 
-    // static async _handleItem(actor, type, args) {
-    //     Logging.debug('_handleItem', actor, type, args);
-
-    // }
-
-    // static async handleEquipment(actor, args) {
-    //     Logging.debug('handleEquipment', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args);
-    // }
-
-    // static async handleArmor(actor, args) {
-    //     Logging.debug('handleArmor', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'armor', args);
-    // }
-
-    // static async handleWeapon(actor, args) {
-    //     Logging.debug('handleWeapon', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'attack', args);
-    // }
-
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
     static async _handleIotum(actor, args) {
         Logging.debug('_handleIotum', actor, args);
 
-        // let itemName = args.name;
         let itemLevel = args.level || 1;
-        // let quantity = parseInt(args.quantity);
-        // let itemData = null;
 
         await AllSystems.handleStackedItem(actor, 'material', args, { ['basic.level']: itemLevel }, 'system.basic.quantity');
-
-        // const linkInfo = args.link;
-        // // if a link is provided and valid, get name and level from it
-        // if (linkInfo?.id !== undefined) {
-        //     const item = await fromUuid(linkInfo.id);
-        //     Logging.debug("(link) item", item);
-
-        //     itemName = item.name;
-        //     Logging.debug('itemName', itemName);
-
-        //     itemLevel = item.system.basic.level || args.level || 1;
-        //     Logging.debug("itemLevel", itemLevel);
-
-        //     itemData = item.system;
-        //     Logging.debug("itemData", itemData);
-        // }
-
-        // Logging.debug("actor items", actor.collections.items);
-        // for (let item of actor.collections.items) {
-        //     Logging.debug("item", item);
-
-        //     if (item.type == 'material' && item.name.toLowerCase() == itemName.toLowerCase()) {
-        //         const currentAmount = parseInt(item.system.basic.quantity || 1);
-        //         Logging.debug("currentAmount", typeof (currentAmount), currentAmount);
-        //         Logging.debug("quantity", typeof (quantity), quantity);
-
-        //         const newAmount = parseInt(currentAmount) + parseInt(quantity);
-        //         Logging.debug("newAmount", newAmount);
-
-        //         item.update({ 'system.basic.quantity': newAmount });
-
-        //         return;
-        //     }
-        // }
-
-        // const data = { name: itemName, type: 'material', basic: { quantity: quantity, level: itemLevel } };
-        // Logging.debug("data", data);
-        // const item = await Item.create([data], { parent: actor });
-        // Logging.debug("item", item);
     }
 
-    // static async handleCypher(actor, args) {
-    //     Logging.debug('handleCypher', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'cypher', args);
-    // }
-
-    // static async handleArtifact(actor, args) {
-    //     Logging.debug('handleArtifact', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'artifact', args);
-    // }
-
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
     static async _handleParts(actor, args) {
         Logging.debug('_handleParts', actor, args);
-
-        // let quantity = parseInt(args.quantity);
-        // Logging.debug('quantity', quantity);
 
         args.name = game.i18n.localize('LOOTPARCELS.Parts');
 
         await AllSystems.handleStackedItem(actor, 'material', args, {}, 'system.basic.quantity');
-
-        // // lookup parts item in actor sheet
-        // let foundParts = false;
-        // for (let item of actor.collections.items) {
-        //     Logging.debug("item", item);
-
-        //     if (item.type == 'material' && item.name.toLowerCase() == 'parts') {
-        //         const currentAmount = parseInt(item.system.basic.quantity || 1);
-        //         Logging.debug("currentAmount", currentAmount);
-
-        //         const newAmount = currentAmount + quantity;
-        //         Logging.debug("newAmount", newAmount);
-
-        //         item.update({ 'system.basic.quantity': newAmount });
-
-        //         // foundParts = true;
-        //         return;
-        //     }
-        // }
-
-        // // Logging.debug("foundParts", foundParts);
-        // // if (!foundParts) {
-        // // add an entry
-        // const data = [{ name: "Parts", type: 'material', 'basic.quantity': quantity }];
-        // const plan = await Item.create(data, { parent: actor });
-        // Logging.debug("plan", plan);
-        // // }
     }
 
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
     static async _handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
-        let name = args.name;
+        let name = args.name || 'default';
         let quantity = args.quantity;
 
         const currencyCount = parseInt(actor.system.settings.equipment.currency.numberCategories);

--- a/scripts/handlers-cyphersystem.js
+++ b/scripts/handlers-cyphersystem.js
@@ -1,146 +1,209 @@
-'use strict';
 
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class CypherSystem {
+    static stackedItemTypes = ['material'];
 
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', CypherSystem.handleCurrency);
-        Registry.registerLootHandler('parts', CypherSystem.handleParts);
-        Registry.registerLootHandler('iotum', CypherSystem.handleIotum);
-        Registry.registerLootHandler('equipment', CypherSystem.handleEquipment);
-        Registry.registerLootHandler('item', CypherSystem.handleEquipment);
-        Registry.registerLootHandler('gear', CypherSystem.handleEquipment);
-        Registry.registerLootHandler('armor', CypherSystem.handleArmor);
-        Registry.registerLootHandler('weapon', CypherSystem.handleWeapon);
-        Registry.registerLootHandler('cypher', CypherSystem.handleCypher);
-        Registry.registerLootHandler('artifact', CypherSystem.handleArtifact);
+        Registry.registerLinkEntryHandler(CypherSystem._handleLinkEntry);
+        Registry.registerTextEntryHandler(CypherSystem._handleTextEntry);
+        Registry.registerDirectiveHandler('currency', CypherSystem._handleCurrency);
+        // Registry.registerLootHandler('currency', CypherSystem.handleCurrency);
+        Registry.registerDirectiveHandler('parts', CypherSystem._handleParts);
+        Registry.registerDirectiveHandler('iotum', CypherSystem._handleIotum);
+        // Registry.registerLootHandler('equipment', CypherSystem.handleEquipment);
+        // Registry.registerLootHandler('item', CypherSystem.handleEquipment);
+        // Registry.registerLootHandler('gear', CypherSystem.handleEquipment);
+        // Registry.registerLootHandler('armor', CypherSystem.handleArmor);
+        // Registry.registerLootHandler('weapon', CypherSystem.handleWeapon);
+        // Registry.registerLootHandler('cypher', CypherSystem.handleCypher);
+        // Registry.registerLootHandler('artifact', CypherSystem.handleArtifact);
     }
 
-    static async _handleItem(actor, type, args) {
-        Logging.debug('_handleItem', actor, type, args);
+    static _shouldStackItem(item) {
+        Logging.debug('_shouldStackItem', item);
 
-    }
-
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
-
-        await AllSystems.handleItem(actor, 'equipment', args);
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'armor', args);
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'attack', args);
-    }
-
-    static async handleIotum(actor, args) {
-        Logging.debug('handleIotum', actor, args);
-
-        let itemName = args.name;
-        let itemDesc = "";
-        let itemLevel = args.level;
-        let quantity = parseInt(args.quantity);
-        let itemData = null;
-
-        const linkInfo = args.link;
-        // if a link is provided and valid, get name and level from it
-        if (linkInfo?.id !== undefined) {
-            const item = await fromUuid(linkInfo.id);
-            Logging.debug("(link) item", item);
-
-            itemName = item.name;
-            Logging.debug('itemName', itemName);
-            itemDesc = item.system.description || "";
-
-            itemLevel = item.system.basic.level || args.level || 1;
-            Logging.debug("itemLevel", itemLevel);
-
-            itemData = item.system;
-            Logging.debug("itemData", itemData);
+        if (this.stackedItemTypes.includes(item.type.toLowerCase())) {
+            return true;
         }
 
-        Logging.debug("actor items", actor.collections.items);
-        for (let item of actor.collections.items) {
-            Logging.debug("item", item);
+        return false;
+    }
 
-            if (item.type == 'material' && item.name.toLowerCase() == itemName.toLowerCase()) {
-                const currentAmount = parseInt(item.system.basic.quantity || 1);
-                Logging.debug("currentAmount", typeof (currentAmount), currentAmount);
-                Logging.debug("quantity", typeof (quantity), quantity);
+    static async _handleLinkEntry(actor, args) {
+        Logging.debug('_handleLinkEntry', actor, args);
 
-                const newAmount = parseInt(currentAmount) + parseInt(quantity);
-                Logging.debug("newAmount", newAmount);
-
-                item.update({ 'system.basic.quantity': newAmount });
-
-                return;
+        const item = await fromUuid(args.link.id);
+        Logging.debug('item', item);
+        const stacked = args.stacked || CypherSystem._shouldStackItem(item);
+        const type = item.type;
+        Logging.debug('type', type, 'stacked', stacked);
+        const addlSystemInfo = {};
+        if(args.level) {
+            addlSystemInfo['basic'] = {
+                'level': args.level,
             }
         }
+        Logging.debug('addlSystemInfo', addlSystemInfo);
 
-        const data = [{ name: itemName, type: 'material', basic: { quantity: quantity, level: itemLevel }, description: itemDesc }];
-        Logging.debug("data", data);
-        const item = await Item.create(data, { parent: actor });
-        Logging.debug("item", item);
+        if (stacked) {
+            await AllSystems.handleStackedItem(actor, type, args, addlSystemInfo, 'system.basic.quantity');
+        }
+        else {
+            await AllSystems.handleItem(actor, type, args, addlSystemInfo, 'system.basic.quantity');
+        }
     }
 
-    static async handleCypher(actor, args) {
-        Logging.debug('handleCypher', actor, args);
+    static async _handleTextEntry(actor, args) {
+        Logging.debug('_handleTextEntry', actor, args);
 
-        await AllSystems.handleItem(actor, 'cypher', args);
-    }
-
-    static async handleArtifact(actor, args) {
-        Logging.debug('handleArtifact', actor, args);
-
-        await AllSystems.handleItem(actor, 'artifact', args);
-    }
-
-    static async handleParts(actor, args) {
-        Logging.debug('handleParts', actor, args);
-
-        let quantity = parseInt(args.quantity);
-        Logging.debug('quantity', quantity);
-
-        // lookup parts item in actor sheet
-        let foundParts = false;
-        for (let item of actor.collections.items) {
-            Logging.debug("item", item);
-
-            if (item.type == 'material' && item.name.toLowerCase() == 'parts') {
-                const currentAmount = parseInt(item.system.basic.quantity || 1);
-                Logging.debug("currentAmount", currentAmount);
-
-                const newAmount = currentAmount + quantity;
-                Logging.debug("newAmount", newAmount);
-
-                item.update({ 'system.basic.quantity': newAmount });
-
-                // foundParts = true;
-                return;
+        const stacked = args.stacked || false;
+        const type = args.type || 'item';
+        Logging.debug('type', type, 'stacked', stacked);
+        const addlSystemInfo = {};
+        if(args.level) {
+            addlSystemInfo['basic'] = {
+                'level': args.level,
             }
         }
+        Logging.debug('addlSystemInfo', addlSystemInfo);
 
-        // Logging.debug("foundParts", foundParts);
-        // if (!foundParts) {
-        // add an entry
-        const data = [{ name: "Parts", type: 'material', 'basic.quantity': quantity }];
-        const plan = await Item.create(data, { parent: actor });
-        Logging.debug("plan", plan);
+        if (stacked) {
+            await AllSystems.handleStackedItem(actor, type, args, addlSystemInfo, 'system.basic.quantity');
+        }
+        else {
+            await AllSystems.handleItem(actor, type, args, addlSystemInfo, 'system.basic.quantity');
+        }
+    }
+
+    // static async _handleItem(actor, type, args) {
+    //     Logging.debug('_handleItem', actor, type, args);
+
+    // }
+
+    // static async handleEquipment(actor, args) {
+    //     Logging.debug('handleEquipment', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
+
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'armor', args);
+    // }
+
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'attack', args);
+    // }
+
+    static async _handleIotum(actor, args) {
+        Logging.debug('_handleIotum', actor, args);
+
+        // let itemName = args.name;
+        let itemLevel = args.level || 1;
+        // let quantity = parseInt(args.quantity);
+        // let itemData = null;
+
+        await AllSystems.handleStackedItem(actor, 'material', args, { ['basic.level']: itemLevel }, 'system.basic.quantity');
+
+        // const linkInfo = args.link;
+        // // if a link is provided and valid, get name and level from it
+        // if (linkInfo?.id !== undefined) {
+        //     const item = await fromUuid(linkInfo.id);
+        //     Logging.debug("(link) item", item);
+
+        //     itemName = item.name;
+        //     Logging.debug('itemName', itemName);
+
+        //     itemLevel = item.system.basic.level || args.level || 1;
+        //     Logging.debug("itemLevel", itemLevel);
+
+        //     itemData = item.system;
+        //     Logging.debug("itemData", itemData);
         // }
+
+        // Logging.debug("actor items", actor.collections.items);
+        // for (let item of actor.collections.items) {
+        //     Logging.debug("item", item);
+
+        //     if (item.type == 'material' && item.name.toLowerCase() == itemName.toLowerCase()) {
+        //         const currentAmount = parseInt(item.system.basic.quantity || 1);
+        //         Logging.debug("currentAmount", typeof (currentAmount), currentAmount);
+        //         Logging.debug("quantity", typeof (quantity), quantity);
+
+        //         const newAmount = parseInt(currentAmount) + parseInt(quantity);
+        //         Logging.debug("newAmount", newAmount);
+
+        //         item.update({ 'system.basic.quantity': newAmount });
+
+        //         return;
+        //     }
+        // }
+
+        // const data = { name: itemName, type: 'material', basic: { quantity: quantity, level: itemLevel } };
+        // Logging.debug("data", data);
+        // const item = await Item.create([data], { parent: actor });
+        // Logging.debug("item", item);
     }
 
-    static async handleCurrency(actor, args) {
+    // static async handleCypher(actor, args) {
+    //     Logging.debug('handleCypher', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'cypher', args);
+    // }
+
+    // static async handleArtifact(actor, args) {
+    //     Logging.debug('handleArtifact', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'artifact', args);
+    // }
+
+    static async _handleParts(actor, args) {
+        Logging.debug('_handleParts', actor, args);
+
+        // let quantity = parseInt(args.quantity);
+        // Logging.debug('quantity', quantity);
+
+        args.name = game.i18n.localize('LOOTPARCELS.Parts');
+
+        await AllSystems.handleStackedItem(actor, 'material', args, {}, 'system.basic.quantity');
+
+        // // lookup parts item in actor sheet
+        // let foundParts = false;
+        // for (let item of actor.collections.items) {
+        //     Logging.debug("item", item);
+
+        //     if (item.type == 'material' && item.name.toLowerCase() == 'parts') {
+        //         const currentAmount = parseInt(item.system.basic.quantity || 1);
+        //         Logging.debug("currentAmount", currentAmount);
+
+        //         const newAmount = currentAmount + quantity;
+        //         Logging.debug("newAmount", newAmount);
+
+        //         item.update({ 'system.basic.quantity': newAmount });
+
+        //         // foundParts = true;
+        //         return;
+        //     }
+        // }
+
+        // // Logging.debug("foundParts", foundParts);
+        // // if (!foundParts) {
+        // // add an entry
+        // const data = [{ name: "Parts", type: 'material', 'basic.quantity': quantity }];
+        // const plan = await Item.create(data, { parent: actor });
+        // Logging.debug("plan", plan);
+        // // }
+    }
+
+    static async _handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
         let name = args.name;
@@ -152,9 +215,7 @@ export class CypherSystem {
         if (name == "" || name == "default") {
             Logging.debug("No name specified");
             // no name specified, so use default
-            const amount = parseInt(actor.system.settings.equipment.currency.quantity1) + parseInt(quantity);
-            Logging.debug('amount', amount);
-            actor.update({ 'system.settings.equipment.currency.quantity1': amount });
+            await AllSystems.updateCurrency(actor, 'system.settings.equipment.currency', 'quantity1', quantity);
             return;
         }
 
@@ -165,15 +226,7 @@ export class CypherSystem {
             const currencyName = actor.system.settings.equipment.currency[nameAttr].trim().toLowerCase();
             Logging.debug('currencyName', currencyName);
             if (currencyName == name) {
-                const amount = parseInt(actor.system.settings.equipment.currency[qtyAttr]) + parseInt(quantity);
-                Logging.debug('amount', amount);
-                const updateAttr = `system.settings.equipment.currency.quantity${i}`;
-                Logging.debug('updateAttr', updateAttr);
-                const data = {
-                    [updateAttr]: amount,
-                };
-                Logging.debug("data", data);
-                actor.update(data);
+                await AllSystems.updateCurrency(actor, 'system.settings.equipment.currency', qtyAttr, quantity);
                 return;
             }
         }

--- a/scripts/handlers-cyphersystem.js
+++ b/scripts/handlers-cyphersystem.js
@@ -4,6 +4,7 @@
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
+import { Utils } from "./utilities.js";
 
 /**
  * Class container for all Cypher System related functions.
@@ -17,26 +18,12 @@ export class CypherSystem {
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
         Registry.registerLinkEntryHandler(CypherSystem._handleLinkEntry);
         Registry.registerTextEntryHandler(CypherSystem._handleTextEntry);
         Registry.registerDirectiveHandler('currency', CypherSystem._handleCurrency);
         Registry.registerDirectiveHandler('parts', CypherSystem._handleParts);
         Registry.registerDirectiveHandler('iotum', CypherSystem._handleIotum);
-    }
-
-    /**
-     *
-     * @param {CypherItem} item
-     * @returns
-     */
-    static _shouldStackItem(item) {
-        Logging.debug('_shouldStackItem', item);
-
-        if (this.stackedItemTypes.includes(item.type.toLowerCase())) {
-            return true;
-        }
-
-        return false;
     }
 
     /**
@@ -49,7 +36,7 @@ export class CypherSystem {
 
         const item = await fromUuid(args.link.id);
         Logging.debug('item', item);
-        const stacked = args.stacked || CypherSystem._shouldStackItem(item);
+        const stacked = args.stacked || Utils.shouldStackItem(item, this.stackedItemTypes);
         const type = item.type;
         Logging.debug('type', type, 'stacked', stacked);
         const addlSystemInfo = {};

--- a/scripts/handlers-demonlord.js
+++ b/scripts/handlers-demonlord.js
@@ -1,23 +1,30 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class SotDLSystem {
     static stackedItemTypes = ['ammo', 'item'];
 
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
         Registry.registerStackedItemTypes(this.stackedItemTypes);
         Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
         Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
-        Registry.registerDirectiveHandler('currency', SotDLSystem.handleCurrency);
+        Registry.registerDirectiveHandler('currency', SotDLSystem._handleCurrency);
     }
 
-    static async handleCurrency(actor, args) {
-        Logging.debug('handleCurrency', actor, args);
+    static async _handleCurrency(actor, args) {
+        Logging.debug('_handleCurrency', actor, args);
 
         let name = args.text;
         let quantity = args.quantity;

--- a/scripts/handlers-demonlord.js
+++ b/scripts/handlers-demonlord.js
@@ -5,53 +5,21 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class SotDLSystem {
+    static stackedItemTypes = ['ammo', 'item'];
+
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', SotDLSystem.handleCurrency);
-        Registry.registerLootHandler('item', SotDLSystem.handleEquipment);
-        Registry.registerLootHandler('equipment', SotDLSystem.handleEquipment);
-        Registry.registerLootHandler('gear', SotDLSystem.handleEquipment);
-        Registry.registerLootHandler('consumable', SotDLSystem.handleConsumable);
-        Registry.registerLootHandler('armor', SotDLSystem.handleArmor);
-        Registry.registerLootHandler('weapon', SotDLSystem.handleWeapon);
-        Registry.registerLootHandler('ammo', SotDLSystem.handleAmmo);
-    }
-
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
-
-        await AllSystems.handleItem(actor, 'item', args);
-    }
-
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'item', args);
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'armor', args);
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
-
-    static async handleAmmo(actor, args) {
-        Logging.debug('handleAmmo', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'ammo', args);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', SotDLSystem.handleCurrency);
     }
 
     static async handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
-        let name = args.name;
+        let name = args.text;
         let quantity = args.quantity;
 
         if (name == "" || name == "default") {
@@ -65,8 +33,9 @@ export class SotDLSystem {
         Logging.debug('amount', amount);
         const updateAttr = `system.wealth.${name}`;
         Logging.debug("updateAttr", updateAttr);
-        const data = {}
-        data[updateAttr] = amount;
+        const data = {
+            [updateAttr]: amount,
+        };
         Logging.debug("data", data);
         await actor.update(data);
     }

--- a/scripts/handlers-dnd5e.js
+++ b/scripts/handlers-dnd5e.js
@@ -5,60 +5,66 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class DnD5eSystem {
+    static stackedItemTypes = ['consumable', 'loot', 'tool'];
+
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        Registry.registerLootHandler('equipment', DnD5eSystem.handleEquipment);
-        Registry.registerLootHandler('item', DnD5eSystem.handleEquipment);
-        Registry.registerLootHandler('gear', DnD5eSystem.handleEquipment);
-        Registry.registerLootHandler('consumable', DnD5eSystem.handleConsumable);
-        Registry.registerLootHandler('container', DnD5eSystem.handleContainer);
-        Registry.registerLootHandler('loot', DnD5eSystem.handleLoot);
-        Registry.registerLootHandler('tool', DnD5eSystem.handleTool);
-        Registry.registerLootHandler('armor', DnD5eSystem.handleArmor);
-        Registry.registerLootHandler('weapon', DnD5eSystem.handleWeapon);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
+        // Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
+        // Registry.registerLootHandler('equipment', DnD5eSystem.handleEquipment);
+        // Registry.registerLootHandler('item', DnD5eSystem.handleEquipment);
+        // Registry.registerLootHandler('gear', DnD5eSystem.handleEquipment);
+        // Registry.registerLootHandler('consumable', DnD5eSystem.handleConsumable);
+        // Registry.registerLootHandler('container', DnD5eSystem.handleContainer);
+        // Registry.registerLootHandler('loot', DnD5eSystem.handleLoot);
+        // Registry.registerLootHandler('tool', DnD5eSystem.handleTool);
+        // Registry.registerLootHandler('armor', DnD5eSystem.handleArmor);
+        // Registry.registerLootHandler('weapon', DnD5eSystem.handleWeapon);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    // static async handleEquipment(actor, args) {
+    //     Logging.debug('handleEquipment', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args);
+    // }
 
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
 
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
+    //     await AllSystems.handleItem(actor, 'weapon', args);
+    // }
 
-    static async handleLoot(actor, args) {
-        Logging.debug('handleLoot', actor, args);
+    // static async handleLoot(actor, args) {
+    //     Logging.debug('handleLoot', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'loot', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'loot', args);
+    // }
 
-    static async handleTool(actor, args) {
-        Logging.debug('handleTool', actor, args);
+    // static async handleTool(actor, args) {
+    //     Logging.debug('handleTool', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'tool', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'tool', args);
+    // }
 
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
+    // static async handleContainer(actor, args) {
+    //     Logging.debug('handleContainer', actor, args);
 
-        await AllSystems.handleItem(actor, 'container', args);
-    }
+    //     await AllSystems.handleItem(actor, 'container', args);
+    // }
 
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
+    // static async handleConsumable(actor, args) {
+    //     Logging.debug('handleConsumable', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
+    // }
 }

--- a/scripts/handlers-dnd5e.js
+++ b/scripts/handlers-dnd5e.js
@@ -14,57 +14,6 @@ export class DnD5eSystem {
         Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
         Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
         Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
-        // Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        // Registry.registerLootHandler('equipment', DnD5eSystem.handleEquipment);
-        // Registry.registerLootHandler('item', DnD5eSystem.handleEquipment);
-        // Registry.registerLootHandler('gear', DnD5eSystem.handleEquipment);
-        // Registry.registerLootHandler('consumable', DnD5eSystem.handleConsumable);
-        // Registry.registerLootHandler('container', DnD5eSystem.handleContainer);
-        // Registry.registerLootHandler('loot', DnD5eSystem.handleLoot);
-        // Registry.registerLootHandler('tool', DnD5eSystem.handleTool);
-        // Registry.registerLootHandler('armor', DnD5eSystem.handleArmor);
-        // Registry.registerLootHandler('weapon', DnD5eSystem.handleWeapon);
     }
 
-    // static async handleEquipment(actor, args) {
-    //     Logging.debug('handleEquipment', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args);
-    // }
-
-    // static async handleArmor(actor, args) {
-    //     Logging.debug('handleArmor', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args);
-    // }
-
-    // static async handleWeapon(actor, args) {
-    //     Logging.debug('handleWeapon', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'weapon', args);
-    // }
-
-    // static async handleLoot(actor, args) {
-    //     Logging.debug('handleLoot', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'loot', args);
-    // }
-
-    // static async handleTool(actor, args) {
-    //     Logging.debug('handleTool', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'tool', args);
-    // }
-
-    // static async handleContainer(actor, args) {
-    //     Logging.debug('handleContainer', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'container', args);
-    // }
-
-    // static async handleConsumable(actor, args) {
-    //     Logging.debug('handleConsumable', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
-    // }
 }

--- a/scripts/handlers-genesys.js
+++ b/scripts/handlers-genesys.js
@@ -5,57 +5,18 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class GenesysSystem {
+    static stackedItemTypes = ['consumable', 'gear'];
+
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', GenesysSystem.handleCurrency);
-        Registry.registerLootHandler('item', GenesysSystem.handleEquipment);
-        Registry.registerLootHandler('equipment', GenesysSystem.handleEquipment);
-        Registry.registerLootHandler('gear', GenesysSystem.handleEquipment);
-        Registry.registerLootHandler('armor', GenesysSystem.handleArmor);
-        Registry.registerLootHandler('weapon', GenesysSystem.handleWeapon);
-        Registry.registerLootHandler('container', GenesysSystem.handleContainer);
-        Registry.registerLootHandler('vehicleweapon', GenesysSystem.handleVehicleWeapon);
-        Registry.registerLootHandler('consumable', GenesysSystem.handleConsumable);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', GenesysSystem._handleCurrency);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
-
-        await AllSystems.handleItem(actor, 'gear', args);
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'armor', args);
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
-
-    static async handleVehicleWeapon(actor, args) {
-        Logging.debug('handleVehicleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'vehicleWeapon', args);
-    }
-
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
-
-        await AllSystems.handleItem(actor, 'container', args);
-    }
-
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
-
-    static async handleCurrency(actor, args) {
+    static async _handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
         let quantity = args.quantity;

--- a/scripts/handlers-pf1.js
+++ b/scripts/handlers-pf1.js
@@ -1,73 +1,34 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class PF1System {
+
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        Registry.registerLootHandler('ammo', PF1System.handleAmmo);
-        Registry.registerLootHandler('ammunition', PF1System.handleAmmo);
-        Registry.registerLootHandler('equipment', PF1System.handleEquipment);
-        Registry.registerLootHandler('item', PF1System.handleEquipment);
-        Registry.registerLootHandler('gear', PF1System.handleEquipment);
-        Registry.registerLootHandler('container', PF1System.handleContainer);
-        Registry.registerLootHandler('consumable', PF1System.handleConsumable);
-        Registry.registerLootHandler('loot', PF1System.handleLoot);
-        Registry.registerLootHandler('armor', PF1System.handleArmor);
-        Registry.registerLootHandler('weapon', PF1System.handleWeapon);
-        Registry.registerLootHandler('wondrous', PF1System.handleWondrous);
+        Registry.registerStackedItemCallback(PF1System._isItemStackable);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    static _isItemStackable(item) {
+        Logging.debug("_isItemStackable", item);
 
-        await AllSystems.handleItem(actor, 'equipment', args, {subtype: ''});
-    }
-
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
-
-        await AllSystems.handleItem(actor, 'container', args);
-    }
-
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
-
-    static async handleLoot(actor, args) {
-        Logging.debug('handleLoot', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'loot', args, {subtype: 'misc'});
-    }
-
-    static async handleAmmo(actor, args) {
-        Logging.debug('handleAmmo', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'loot', args, {subtype: 'ammo'});
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'equipment', args, {subtype: 'armor'});
-    }
-
-    static async handleWondrous(actor, args) {
-        Logging.debug('handleWondrous', actor, args);
-
-        await AllSystems.handleItem(actor, 'equipment', args, {subtype: 'wondrous'});
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'weapon', args);
+        return ((item.type == 'consumable') ||
+            (item.type == 'loot' &&
+                (item.system.subType == 'misc' ||
+                    item.system.subType == 'ammo')));
     }
 
 }

--- a/scripts/handlers-pf2e.js
+++ b/scripts/handlers-pf2e.js
@@ -5,7 +5,6 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class PF2eSystem {
-    // static stackedItemTypes = ['consumable', 'ammunition', 'tool', 'gear', 'currency', 'sundry'];
     static currencySlugMap = {
         'gp': 'gold-pieces',
         'sp': 'silver-pieces',
@@ -20,20 +19,6 @@ export class PF2eSystem {
         Registry.registerStackedItemCallback(PF2eSystem._isItemStackable);
         Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
         Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
-
-        // Registry.registerLootHandler('ammo', PF2eSystem.handleAmmo);
-        // Registry.registerLootHandler('ammunition', PF2eSystem.handleAmmo);
-        // Registry.registerLootHandler('equipment', PF2eSystem.handleEquipment);
-        // Registry.registerLootHandler('item', PF2eSystem.handleEquipment);
-        // Registry.registerLootHandler('gear', PF2eSystem.handleEquipment);
-        // Registry.registerLootHandler('container', PF2eSystem.handleContainer);
-        // Registry.registerLootHandler('consumable', PF2eSystem.handleConsumable);
-        // Registry.registerLootHandler('loot', PF2eSystem.handleLoot);
-        // Registry.registerLootHandler('armor', PF2eSystem.handleArmor);
-        // Registry.registerLootHandler('shield', PF2eSystem.handleShield);
-        // Registry.registerLootHandler('weapon', PF2eSystem.handleWeapon);
-        // Registry.registerLootHandler('treasure', PF2eSystem.handleTreasure);
-        // Registry.registerLootHandler('kit', PF2eSystem.handleKit);
     }
 
     static _isItemStackable(item) {
@@ -47,66 +32,6 @@ export class PF2eSystem {
                     item.system.subType == 'ammo')));
     }
 
-    // static async handleEquipment(actor, args) {
-    //     Logging.debug('handleEquipment', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args, { subtype: '' });
-    // }
-
-    // static async handleContainer(actor, args) {
-    //     Logging.debug('handleContainer', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'container', args);
-    // }
-
-    // static async handleConsumable(actor, args) {
-    //     Logging.debug('handleConsumable', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
-    // }
-
-    // static async handleLoot(actor, args) {
-    //     Logging.debug('handleLoot', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'misc' });
-    // }
-
-    // static async handleAmmo(actor, args) {
-    //     Logging.debug('handleAmmo', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'ammo' });
-    // }
-
-    // static async handleArmor(actor, args) {
-    //     Logging.debug('handleArmor', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'equipment', args, { subtype: 'armor' });
-    // }
-
-    // static async handleShield(actor, args) {
-    //     Logging.debug('handleShield', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'shield', args);
-    // }
-
-    // static async handleKit(actor, args) {
-    //     Logging.debug('handleKit', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'kit', args);
-    // }
-
-    // static async handleTreasure(actor, args) {
-    //     Logging.debug('handleTreasure', actor, args);
-
-    //     await AllSystems.handleStackedItem(actor, 'treasure', args);
-    // }
-
-    // static async handleWeapon(actor, args) {
-    //     Logging.debug('handleWeapon', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'weapon', args);
-    // }
-
     static async _handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
@@ -119,12 +44,10 @@ export class PF2eSystem {
 
             if (item.system.stackGroup == 'coins' && item.system.slug == PF2eSystem.currencySlugMap[name]) {
                 // adjust quantity
-                // const currentAmount = parseInt(item.system.price.value[name]);
                 const currentAmount = parseInt(item.system.quantity);
                 Logging.debug('currentAmount', currentAmount);
                 const newAmount = currentAmount + quantity;
                 Logging.debug('newAmount', newAmount);
-                // const data = { [`system.price.value.${name}`]: newAmount };
                 const data = { ['system.quantity']: newAmount };
                 await item.update(data);
                 return;
@@ -138,6 +61,5 @@ export class PF2eSystem {
 
         const qtyData = { 'system.quantity': quantity };
         await item.update(qtyData);
-        // await AllSystems.handleStackedItem(actor, 'treasure', args, { stackGroup: 'coins', slug:  })
     }
 }

--- a/scripts/handlers-pf2e.js
+++ b/scripts/handlers-pf2e.js
@@ -5,6 +5,7 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class PF2eSystem {
+    // static stackedItemTypes = ['consumable', 'ammunition', 'tool', 'gear', 'currency', 'sundry'];
     static currencySlugMap = {
         'gp': 'gold-pieces',
         'sp': 'silver-pieces',
@@ -15,83 +16,98 @@ export class PF2eSystem {
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', PF2eSystem.handleCurrency);
-        Registry.registerLootHandler('ammo', PF2eSystem.handleAmmo);
-        Registry.registerLootHandler('ammunition', PF2eSystem.handleAmmo);
-        Registry.registerLootHandler('equipment', PF2eSystem.handleEquipment);
-        Registry.registerLootHandler('item', PF2eSystem.handleEquipment);
-        Registry.registerLootHandler('gear', PF2eSystem.handleEquipment);
-        Registry.registerLootHandler('container', PF2eSystem.handleContainer);
-        Registry.registerLootHandler('consumable', PF2eSystem.handleConsumable);
-        Registry.registerLootHandler('loot', PF2eSystem.handleLoot);
-        Registry.registerLootHandler('armor', PF2eSystem.handleArmor);
-        Registry.registerLootHandler('shield', PF2eSystem.handleShield);
-        Registry.registerLootHandler('weapon', PF2eSystem.handleWeapon);
-        Registry.registerLootHandler('treasure', PF2eSystem.handleTreasure);
-        Registry.registerLootHandler('kit', PF2eSystem.handleKit);
+        Registry.registerDirectiveHandler('currency', PF2eSystem._handleCurrency);
+        Registry.registerStackedItemCallback(PF2eSystem._isItemStackable);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+
+        // Registry.registerLootHandler('ammo', PF2eSystem.handleAmmo);
+        // Registry.registerLootHandler('ammunition', PF2eSystem.handleAmmo);
+        // Registry.registerLootHandler('equipment', PF2eSystem.handleEquipment);
+        // Registry.registerLootHandler('item', PF2eSystem.handleEquipment);
+        // Registry.registerLootHandler('gear', PF2eSystem.handleEquipment);
+        // Registry.registerLootHandler('container', PF2eSystem.handleContainer);
+        // Registry.registerLootHandler('consumable', PF2eSystem.handleConsumable);
+        // Registry.registerLootHandler('loot', PF2eSystem.handleLoot);
+        // Registry.registerLootHandler('armor', PF2eSystem.handleArmor);
+        // Registry.registerLootHandler('shield', PF2eSystem.handleShield);
+        // Registry.registerLootHandler('weapon', PF2eSystem.handleWeapon);
+        // Registry.registerLootHandler('treasure', PF2eSystem.handleTreasure);
+        // Registry.registerLootHandler('kit', PF2eSystem.handleKit);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    static _isItemStackable(item) {
+        Logging.debug("_isItemStackable", item);
 
-        await AllSystems.handleItem(actor, 'equipment', args, { subtype: '' });
+        return ((item.type == 'consumable') ||
+        (item.type == 'kit') ||
+        (item.type == 'treasure') ||
+            (item.type == 'loot' &&
+                (item.system.subType == 'misc' ||
+                    item.system.subType == 'ammo')));
     }
 
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
+    // static async handleEquipment(actor, args) {
+    //     Logging.debug('handleEquipment', actor, args);
 
-        await AllSystems.handleItem(actor, 'container', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args, { subtype: '' });
+    // }
 
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
+    // static async handleContainer(actor, args) {
+    //     Logging.debug('handleContainer', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'consumable', args);
-    }
+    //     await AllSystems.handleItem(actor, 'container', args);
+    // }
 
-    static async handleLoot(actor, args) {
-        Logging.debug('handleLoot', actor, args);
+    // static async handleConsumable(actor, args) {
+    //     Logging.debug('handleConsumable', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'misc' });
-    }
+    //     await AllSystems.handleStackedItem(actor, 'consumable', args);
+    // }
 
-    static async handleAmmo(actor, args) {
-        Logging.debug('handleAmmo', actor, args);
+    // static async handleLoot(actor, args) {
+    //     Logging.debug('handleLoot', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'ammo' });
-    }
+    //     await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'misc' });
+    // }
 
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
+    // static async handleAmmo(actor, args) {
+    //     Logging.debug('handleAmmo', actor, args);
 
-        await AllSystems.handleItem(actor, 'equipment', args, { subtype: 'armor' });
-    }
+    //     await AllSystems.handleStackedItem(actor, 'loot', args, { subtype: 'ammo' });
+    // }
 
-    static async handleShield(actor, args) {
-        Logging.debug('handleShield', actor, args);
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
 
-        await AllSystems.handleItem(actor, 'shield', args);
-    }
+    //     await AllSystems.handleItem(actor, 'equipment', args, { subtype: 'armor' });
+    // }
 
-    static async handleKit(actor, args) {
-        Logging.debug('handleKit', actor, args);
+    // static async handleShield(actor, args) {
+    //     Logging.debug('handleShield', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'kit', args);
-    }
+    //     await AllSystems.handleItem(actor, 'shield', args);
+    // }
 
-    static async handleTreasure(actor, args) {
-        Logging.debug('handleTreasure', actor, args);
+    // static async handleKit(actor, args) {
+    //     Logging.debug('handleKit', actor, args);
 
-        await AllSystems.handleStackedItem(actor, 'treasure', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'kit', args);
+    // }
 
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
+    // static async handleTreasure(actor, args) {
+    //     Logging.debug('handleTreasure', actor, args);
 
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, 'treasure', args);
+    // }
 
-    static async handleCurrency(actor, args) {
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
+
+    //     await AllSystems.handleItem(actor, 'weapon', args);
+    // }
+
+    static async _handleCurrency(actor, args) {
         Logging.debug('handleCurrency', actor, args);
 
         const name = args.name || 'gp';
@@ -103,17 +119,19 @@ export class PF2eSystem {
 
             if (item.system.stackGroup == 'coins' && item.system.slug == PF2eSystem.currencySlugMap[name]) {
                 // adjust quantity
-                const currentAmount = parseInt(item.system.price.value[name]);
+                // const currentAmount = parseInt(item.system.price.value[name]);
+                const currentAmount = parseInt(item.system.quantity);
                 Logging.debug('currentAmount', currentAmount);
                 const newAmount = currentAmount + quantity;
                 Logging.debug('newAmount', newAmount);
-                const data = { [`system.price.value.${name}`]: newAmount };
+                // const data = { [`system.price.value.${name}`]: newAmount };
+                const data = { ['system.quantity']: newAmount };
                 await item.update(data);
                 return;
             }
         }
 
-        const data = { name: name, type: 'treasure', system: { stackGroup: 'coins', slug: PF2eSystem.currencySlugMap[name], [`price.value.${name}`]: quantity } };
+        const data = { name: name, type: 'treasure', system: { stackGroup: 'coins', slug: PF2eSystem.currencySlugMap[name], [`price.value.${name}`]: 1 } };
         Logging.debug("data", data);
         const item = await Item.create([data], { parent: actor });
         Logging.debug("item", item);

--- a/scripts/handlers-shadowdark.js
+++ b/scripts/handlers-shadowdark.js
@@ -1,43 +1,57 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class ShadowdarkSystem {
+    static stackedItemTypes = ['Basic', 'Potion', 'Scroll', 'Gem', 'Wand'];
+
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', ShadowdarkSystem.handleCurrency);
-        Registry.registerLootHandler('item', ShadowdarkSystem.handleItem);
-        Registry.registerLootHandler('equipment', ShadowdarkSystem.handleItem);
-        Registry.registerLootHandler('gear', ShadowdarkSystem.handleItem);
-        Registry.registerLootHandler('armor', ShadowdarkSystem.handleArmor);
-        Registry.registerLootHandler('weapon', ShadowdarkSystem.handleWeapon);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', ShadowdarkSystem._handleCurrency);
+
+        // Registry.registerLootHandler('currency', ShadowdarkSystem.handleCurrency);
+        // Registry.registerLootHandler('item', ShadowdarkSystem.handleItem);
+        // Registry.registerLootHandler('equipment', ShadowdarkSystem.handleItem);
+        // Registry.registerLootHandler('gear', ShadowdarkSystem.handleItem);
+        // Registry.registerLootHandler('armor', ShadowdarkSystem.handleArmor);
+        // Registry.registerLootHandler('weapon', ShadowdarkSystem.handleWeapon);
     }
 
-    static async handleItem(actor, args) {
-        Logging.debug('handleBasic', actor, args);
+    // static async handleItem(actor, args) {
+    //     Logging.debug('handleBasic', actor, args);
 
-        await AllSystems.handleStackedItem(actor, '', args);
-    }
+    //     await AllSystems.handleStackedItem(actor, '', args);
+    // }
 
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
+    // static async handleArmor(actor, args) {
+    //     Logging.debug('handleArmor', actor, args);
 
-        await AllSystems.handleItem(actor, 'Armor', args);
-    }
+    //     await AllSystems.handleItem(actor, 'Armor', args);
+    // }
 
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
+    // static async handleWeapon(actor, args) {
+    //     Logging.debug('handleWeapon', actor, args);
 
-        await AllSystems.handleItem(actor, 'Weapon', args);
-    }
+    //     await AllSystems.handleItem(actor, 'Weapon', args);
+    // }
 
-    static async handleCurrency(actor, args) {
-        Logging.debug('handleCurrency', actor, args);
+    static async _handleCurrency(actor, args) {
+        Logging.debug('_handleCurrency', actor, args);
 
-        let name = args.name
+        let name = args.text
         let quantity = args.quantity;
 
         const currentAmount = actor.system.coins[name];

--- a/scripts/handlers-tor1e.js
+++ b/scripts/handlers-tor1e.js
@@ -1,46 +1,34 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class TOR1eSystem {
+    static stackedItemTypes = ['miscellaneous'];
+
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        // Registry.registerLootHandler('currency', TOR2eSystem.handleCurrency);
-        // Registry.registerLootHandler('item', TOR2eSystem.handleMisc);
-        // Registry.registerLootHandler('armor', TOR2eSystem.handleArmor);
-        // Registry.registerLootHandler('weapon', TOR2eSystem.handleWeapon);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', TOR1eSystem._handleCurrency);
     }
 
-    // static async handleMisc(actor, args) {
-    //     Logging.debug('handleMisc', actor, args);
+    static async _handleCurrency(actor, args) {
+        Logging.debug('_handleCurrency', actor, args);
 
-    //     await AllSystems.handleItem(actor, 'miscellaneous', args);
-    // }
+        let quantity = args.quantity;
 
-    // static async handleArmor(actor, args) {
-    //     Logging.debug('handleArmor', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'armor', args);
-    // }
-
-    // static async handleWeapon(actor, args) {
-    //     Logging.debug('handleWeapon', actor, args);
-
-    //     await AllSystems.handleItem(actor, 'weapon', args);
-    // }
-
-    // static async handleCurrency(actor, args) {
-    //     Logging.debug('handleCurrency', actor, args);
-
-    //     let quantity = args.quantity;
-
-    //     const currentAmount = actor.system.treasure.value;
-    //     Logging.debug("currentAmount", currentAmount);
-    //     const amount = parseInt(currentAmount) + parseInt(quantity);
-    //     Logging.debug('amount', amount);
-    //     await actor.update({ 'system.treasure.value': amount });
-    // }
+        const currentAmount = actor.system.treasure.value;
+        Logging.debug("currentAmount", currentAmount);
+        const amount = parseInt(currentAmount) + parseInt(quantity);
+        Logging.debug('amount', amount);
+        await actor.update({ ['system.treasure.value']: amount });
+    }
 }

--- a/scripts/handlers-tor2e.js
+++ b/scripts/handlers-tor2e.js
@@ -1,48 +1,30 @@
-'use strict';
-
+/**
+ *
+ */
 import { AllSystems } from "./handlers-all.js";
 import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
+/**
+ *
+ */
 export class TOR2eSystem {
+    static stackedItemTypes = ['miscellaneous'];
+
+    /**
+     *
+     */
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', TOR2eSystem.handleCurrency);
-        Registry.registerLootHandler('item', TOR2eSystem.handleMisc);
-        Registry.registerLootHandler('equipment', TOR2eSystem.handleMisc);
-        Registry.registerLootHandler('gear', TOR2eSystem.handleMisc);
-        Registry.registerLootHandler('consumable', TOR2eSystem.handleConsumable);
-        Registry.registerLootHandler('armor', TOR2eSystem.handleArmor);
-        Registry.registerLootHandler('weapon', TOR2eSystem.handleWeapon);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(AllSystems.handleTextEntry);
+        Registry.registerDirectiveHandler('currency', TOR2eSystem._handleCurrency);
     }
 
-    static async handleMisc(actor, args) {
-        Logging.debug('handleMisc', actor, args);
-
-        await AllSystems.handleItem(actor, 'miscellaneous', args);
-    }
-
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'miscellaneous', args);
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'armor', args);
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'weapon', args);
-    }
-
-    static async handleCurrency(actor, args) {
-        Logging.debug('handleCurrency', actor, args);
+    static async _handleCurrency(actor, args) {
+        Logging.debug('_handleCurrency', actor, args);
 
         let quantity = args.quantity;
 
@@ -50,6 +32,6 @@ export class TOR2eSystem {
         Logging.debug("currentAmount", currentAmount);
         const amount = parseInt(currentAmount) + parseInt(quantity);
         Logging.debug('amount', amount);
-        await actor.update({ 'system.treasure.value': amount });
+        await actor.update({ ['system.treasure.value']: amount });
     }
 }

--- a/scripts/handlers-weirdwizard.js
+++ b/scripts/handlers-weirdwizard.js
@@ -5,47 +5,37 @@ import { Registry } from "./registry.js";
 import { Logging } from "./logging.js";
 
 export class SotWWSystem {
+    static stackedItemTypes = ['Equipment:consumable'];
+
     static registerHandlers() {
         Logging.debug("registerHandlers");
 
-        Registry.registerLootHandler('currency', AllSystems.handleNamedCurrency);
-        Registry.registerLootHandler('equipment', SotWWSystem.handleEquipment);
-        Registry.registerLootHandler('item', SotWWSystem.handleEquipment);
-        Registry.registerLootHandler('gear', SotWWSystem.handleEquipment);
-        Registry.registerLootHandler('consumable', SotWWSystem.handleConsumable);
-        Registry.registerLootHandler('container', SotWWSystem.handleContainer);
-        Registry.registerLootHandler('armor', SotWWSystem.handleArmor);
-        Registry.registerLootHandler('weapon', SotWWSystem.handleWeapon);
+        Registry.registerStackedItemTypes(this.stackedItemTypes);
+        Registry.registerLinkEntryHandler(AllSystems.handleLinkEntry);
+        Registry.registerTextEntryHandler(SotWWSystem._handleTextEntry);
+        Registry.registerDirectiveHandler('currency', AllSystems.handleCurrency);
     }
 
-    static async handleEquipment(actor, args) {
-        Logging.debug('handleEquipment', actor, args);
+    /**
+     *
+     * @param {CypherActor} actor
+     * @param {object} args
+     */
+    static async _handleTextEntry(actor, args) {
+        Logging.debug('_handleTextEntry', actor, args);
 
-        await AllSystems.handleItem(actor, 'Equipment', args, {subtype: 'generic'});
-    }
+        const stacked = args.stacked || false;
+        const type = args.type || 'Equipment';
+        Logging.debug('type', type, 'stacked', stacked);
+        const addlSystemInfo = {subtype: args.subtype || 'generic' };
+        Logging.debug('addlSystemInfo', addlSystemInfo);
 
-    static async handleConsumable(actor, args) {
-        Logging.debug('handleConsumable', actor, args);
-
-        await AllSystems.handleStackedItem(actor, 'Equipment', args, {subtype: 'consumable'});
-    }
-
-    static async handleContainer(actor, args) {
-        Logging.debug('handleContainer', actor, args);
-
-        await AllSystems.handleItem(actor, 'container', args, {subtype: 'container'});
-    }
-
-    static async handleArmor(actor, args) {
-        Logging.debug('handleArmor', actor, args);
-
-        await AllSystems.handleItem(actor, 'armor', args, {subtype: 'armor'});
-    }
-
-    static async handleWeapon(actor, args) {
-        Logging.debug('handleWeapon', actor, args);
-
-        await AllSystems.handleItem(actor, 'weapon', args, {subtype: 'weapon'});
+        if (stacked) {
+            await AllSystems.handleStackedItem(actor, type, args, addlSystemInfo);
+        }
+        else {
+            await AllSystems.handleItem(actor, type, args, addlSystemInfo);
+        }
     }
 
 }

--- a/scripts/parcels.js
+++ b/scripts/parcels.js
@@ -100,7 +100,7 @@ export async function handleParcelDrop(actor, html, droppedEntity) {
             const qty = await Utils.determineQuantity(m);
             Logging.debug("qty", qty);
             if (qty !== undefined && qty !== null) {
-                args['q'] = parseInt(qty);
+                args['quantity'] = parseInt(qty);
                 Logging.debug('args (parsing)', args);
                 remainingLine = remainingLine.replace(m, "");
                 continue;

--- a/scripts/parcels.js
+++ b/scripts/parcels.js
@@ -1,3 +1,7 @@
+/**
+ *
+ */
+
 import { Logging } from "./logging.js";
 import { Utils } from "./utilities.js";
 import { Registry } from "./registry.js";
@@ -7,6 +11,13 @@ const allowedJournalTypes = [
     `${prefix}parcel`,
 ];
 
+/**
+ *
+ * @param {*} actor
+ * @param {*} html
+ * @param {*} droppedEntity
+ * @returns
+ */
 export async function handleParcelDrop(actor, html, droppedEntity) {
     Logging.debug("handleParcelDrop", actor, html, droppedEntity);
 

--- a/scripts/parcels.js
+++ b/scripts/parcels.js
@@ -1,5 +1,5 @@
 /**
- *
+ * Parcel handling functions.
  */
 
 import { Logging } from "./logging.js";
@@ -12,11 +12,12 @@ const allowedJournalTypes = [
 ];
 
 /**
+ * Hook callback function that handles when a parcel is dropped on the actor.
  *
- * @param {*} actor
- * @param {*} html
- * @param {*} droppedEntity
- * @returns
+ * @param {BaseActor} actor An actor appropriate to the active system.
+ * @param {*} html Not used.
+ * @param {JournalEntry} droppedEntity If this is not a journal entry, the function exits early.
+ * @returns Nothing.
  */
 export async function handleParcelDrop(actor, html, droppedEntity) {
     Logging.debug("handleParcelDrop", actor, html, droppedEntity);

--- a/scripts/parcels.js
+++ b/scripts/parcels.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Logging } from "./logging.js";
 import { Utils } from "./utilities.js";
 import { Registry } from "./registry.js";
@@ -34,95 +32,120 @@ export async function handleParcelDrop(actor, html, droppedEntity) {
     journalContent.forEach(async (jc) => {
         // parse line
         let line = jc.trim();
+        let fn = null;
 
-        // get marker
+        // determine type of entry
         const parts = line.split(/\s+/, 1);
         Logging.debug('parts', parts);
         if (parts.length == 0) {
+            // line is empty
             return;
         }
 
-        const fnType = parts[0].substring(1);
-        const fn = Registry.lootHandlers[fnType];
-        Logging.debug("lootHandler", fn);
-
-        if (fn === undefined || fn === "") {
-            ui.notifications.warn(game.i18n.format('LOOTPARCELS.UnsupportedLootType',
-                { name: `${fnType}` }));
-            return;
-        }
-
+        const firstSpace = line.search(/\s/);
+        let remainingLine = line;
         let args = {
             quantity: 1,
+            level: 1,
         };
 
-        // remove marker
-        const firstSpace = line.search(/\s/);
-        let remainingLine = line.substring(firstSpace).trim();
-        Logging.debug("remainingLine", remainingLine);
+        const entryType = parts[0];
+        if (entryType.startsWith(prefix)) {
+            // directive
+            const fnType = entryType.substring(1);
+            fn = Registry.getDirectiveHandler(fnType);
+            Logging.debug("fn", fn);
 
-        // find quantifiers or die specs
-        for (let q of remainingLine.split(/\s+/)) {
-            Logging.debug("quantifier", q);
+            if (fn === undefined || fn === "") {
+                ui.notifications.warn(game.i18n.format('LOOTPARCELS.UnsupportedDirective',
+                    { name: `${fnType}` }));
+                return;
+            }
+
+            // remove directive from line
+            remainingLine = line.substring(firstSpace).trim();
+            Logging.debug("remainingLine", remainingLine);
+        }
+        else if (entryType.startsWith('@')) {
+            // link
+            const linkInfo = Utils.parseLink(line);
+            Logging.debug('linkInfo', linkInfo);
+
+            if (linkInfo === null) {
+                // no match, treat the line as text
+                fn = Registry.getTextEntryHandler();
+                Logging.debug("fn", fn);
+            }
+            else {
+                args['text'] = linkInfo.name;
+                args['link'] = linkInfo;
+
+                // remove link from line
+                remainingLine = line.replace(linkInfo.link, "");
+                fn = Registry.getLinkEntryHandler();
+                Logging.debug("fn", fn);
+            }
+        }
+        else {
+            // text?
+            fn = Registry.getTextEntryHandler();
+            Logging.debug("fn", fn);
+        }
+
+        // find modifiers or die specs
+        for (let m of remainingLine.split(/\s+/)) {
+            Logging.debug("modifier", m);
 
             // check if it's a die spec
-            const qty = await Utils.determineQuantity(q);
+            const qty = await Utils.determineQuantity(m);
             Logging.debug("qty", qty);
             if (qty !== undefined && qty !== null) {
-                args['quantity'] = parseInt(qty);
+                args['q'] = parseInt(qty);
                 Logging.debug('args (parsing)', args);
-                remainingLine = remainingLine.replace(q, "");
+                remainingLine = remainingLine.replace(m, "");
                 continue;
             }
 
             // check if it's a key/value pair
-            const kv = q.split('=');
+            const kv = m.split('=');
             Logging.debug("kv", kv);
             if (kv.length != 2) continue;
 
             switch (kv[0]) {
+                // handle special cases
+                case 'level':
                 case 'l':
                     args['level'] = parseInt(kv[1]);
                     Logging.debug('args (parsing)', args);
-                    remainingLine = remainingLine.replace(q, "");
+                    remainingLine = remainingLine.replace(m, "");
                     break;
+                case 'quantity':
                 case 'q':
                     args['quantity'] = await Utils.determineQuantity(kv[1]);
                     Logging.debug('args (parsing)', args);
-                    remainingLine = remainingLine.replace(q, "");
+                    remainingLine = remainingLine.replace(m, "");
                     break;
-                case 't':
-                    args['type'] = kv[1];
+                default:
+                    args[kv[0]] = kv[1];
                     Logging.debug('args (parsing)', args);
-                    remainingLine = remainingLine.replace(q, "");
+                    remainingLine = remainingLine.replace(m, "");
                     break;
             }
         }
         Logging.debug("remainingLine", remainingLine);
 
-        // determine if there's a link present
-        const linkExpr = /@UUID\[(\S+)\]\{(.+?)\}/;
-        const matchResult = remainingLine.match(linkExpr);
-        Logging.debug('link matchResult', matchResult);
-        if (matchResult === undefined || matchResult === null) {
-            // no match
-            args['name'] = remainingLine.trim();
-        }
-        else {
-            const link = matchResult[0];
-            Logging.debug('link', link);
-            const linkLength = link.length;
-            const linkStart = matchResult.index;
-            const linkInfo = Utils.parseLink(link);
-
-            args['name'] = linkInfo.name;
-            args['link'] = {
-                source: link,
-                ...linkInfo
-            };
+        // if there's anything left, treat it as free text that goes in 'args.text'
+        if (remainingLine.trim().length > 0) {
+            args['text'] = remainingLine.trim();
         }
 
         Logging.debug('args (before call)', args);
+
+        // make sure we have a function to call
+        if (fn === null) {
+            ui.notifications.warn(game.i18n.localize('LOOTPARCELS.NoFunction'));
+            return;
+        }
 
         await fn(actor, args);
     });

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -6,6 +6,7 @@ export class Registry {
     static linkEntryHandler = null;
     static textEntryHandler = null;
     static actorTypes = [];
+    static stackedItemTypes = [];
 
     static getDirectiveHandler(name) {
         Logging.debug("Registry.getDirectiveHandler", name);
@@ -20,6 +21,11 @@ export class Registry {
     static getTextEntryHandler() {
         Logging.debug("Registry.getTextEntryHandler");
         return Registry.textEntryHandler;
+    }
+
+    static getStackedItemTypes() {
+        Logging.debug("Registry.getStackedItemTypes");
+        return Registry.stackedItemTypes;
     }
 
     /**
@@ -40,29 +46,59 @@ export class Registry {
         return false;
     }
 
+    /**
+     *
+     * @param {function} fn
+     */
     static registerLinkEntryHandler(fn) {
         Logging.info("Registering link entry handler");
 
         Registry.linkEntryHandler = fn;
     }
 
+    /**
+     *
+     * @param {function} fn
+     */
     static registerTextEntryHandler(fn) {
         Logging.info("Registering text entry handler");
 
         Registry.textEntryHandler = fn;
     }
 
+    /**
+     *
+     * @param {String} name
+     * @param {function} fn
+     */
     static registerDirectiveHandler(name, fn) {
         Logging.info('Registering directive handler:', name);
 
         Registry.directiveHandlers[name] = fn;
     }
 
+    /**
+     *
+     * @param {Array} types
+     */
+    static registerStackedItemTypes(types) {
+        Logging.info("Registering stacked item types:", types)
+
+        types?.forEach(type => {
+            Logging.debug("Registering stacked item type", type);
+            Registry.stackedItemTypes.push(type.toLowerCase());
+        });
+    }
+
+    /**
+     *
+     * @param {Array} types
+     */
     static registerAcceptableActorTypes(types) {
         Logging.info('Registering actor types:', types);
 
         types?.forEach(type => {
-            Logging.debug("Registering type", type);
+            Logging.debug("Registering actor type", type);
             Registry.actorTypes.push(type.toLowerCase());
         });
     }

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -7,6 +7,7 @@ export class Registry {
     static textEntryHandler = null;
     static actorTypes = [];
     static stackedItemTypes = [];
+    static stackedItemCallback = null;
 
     static getDirectiveHandler(name) {
         Logging.debug("Registry.getDirectiveHandler", name);
@@ -26,6 +27,11 @@ export class Registry {
     static getStackedItemTypes() {
         Logging.debug("Registry.getStackedItemTypes");
         return Registry.stackedItemTypes;
+    }
+
+    static getStackedItemCallback() {
+        Logging.debug("Registry.getStackedItemCallback");
+        return Registry.stackedItemCallback;
     }
 
     /**
@@ -88,6 +94,12 @@ export class Registry {
             Logging.debug("Registering stacked item type", type);
             Registry.stackedItemTypes.push(type.toLowerCase());
         });
+    }
+
+    static registerStackedItemCallback(fn) {
+        Logging.info("Registering stacked item callback", fn);
+
+        Registry.stackedItemCallback = fn;
     }
 
     /**

--- a/scripts/registry.js
+++ b/scripts/registry.js
@@ -1,14 +1,25 @@
-'use strict';
 
 import { Logging } from "./logging.js";
 
 export class Registry {
-    static lootHandlers = {};
+    static directiveHandlers = {};
+    static linkEntryHandler = null;
+    static textEntryHandler = null;
     static actorTypes = [];
 
-    static getHandler(name) {
-        Logging.debug("Registry.getHandler", name);
-        return Registry.lootHandlers[name];
+    static getDirectiveHandler(name) {
+        Logging.debug("Registry.getDirectiveHandler", name);
+        return Registry.directiveHandlers[name];
+    }
+
+    static getLinkEntryHandler() {
+        Logging.debug("Registry.getLinkEntryHandler");
+        return Registry.linkEntryHandler;
+    }
+
+    static getTextEntryHandler() {
+        Logging.debug("Registry.getTextEntryHandler");
+        return Registry.textEntryHandler;
     }
 
     /**
@@ -29,10 +40,22 @@ export class Registry {
         return false;
     }
 
-    static registerLootHandler(name, fn) {
-        Logging.info('Registering loot handler:', name);
+    static registerLinkEntryHandler(fn) {
+        Logging.info("Registering link entry handler");
 
-        Registry.lootHandlers[name] = fn;
+        Registry.linkEntryHandler = fn;
+    }
+
+    static registerTextEntryHandler(fn) {
+        Logging.info("Registering text entry handler");
+
+        Registry.textEntryHandler = fn;
+    }
+
+    static registerDirectiveHandler(name, fn) {
+        Logging.info('Registering directive handler:', name);
+
+        Registry.directiveHandlers[name] = fn;
     }
 
     static registerAcceptableActorTypes(types) {

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -70,7 +70,7 @@ export class Utils {
 			Logging.debug("total", r.total);
 			return r.total;
 		}
-		catch(error) {
+		catch (error) {
 			return null;
 		}
 	}
@@ -90,4 +90,46 @@ export class Utils {
 			name: matchResult[2],
 		};
 	}
+
+	/**
+	 *
+	 * @param {Item} item
+	 * @param {Array} types
+	 * @returns
+	 */
+	static shouldStackItem(item, types) {
+		Logging.debug('Utils.shouldStackItem', item, types);
+
+		const itemType = item.type.toLowerCase();
+		const itemSubtype = item.system.subtype?.toLowerCase() || null;
+
+		for (let type of types) {
+			Logging.debug('type', type);
+			const typeSubtype = type.split(':');
+			Logging.debug("typeSubtype", typeSubtype);
+
+			if (typeSubtype[0] === itemType) {
+				Logging.debug(`Item's type ${itemType} matches`);
+
+				if (typeSubtype.length > 1) {
+					Logging.debug("Registered type requires a subtype", typeSubtype[1]);
+
+					if (typeSubtype[1] === itemSubtype) {
+						Logging.debug(`Item's subtype ${itemSubtype} matches`);
+						return true;
+					}
+
+					Logging.debug("Subtype was required but did not match");
+					return false;
+				}
+
+				Logging.debug("Subtype was not required");
+				return true;
+			}
+		}
+
+		Logging.debug("No item types matched");
+		return false;
+	}
+
 };

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,35 +1,3 @@
-/*
-	Those scripts are aimed solely for the Cypher Systems on FoundryVTT made by Mrkwnzl and will
-	probably (totally in fact) not work with any other systems.
-
-	Those add-ons could be totally added directly inside the Cypher System at a later date
-	All of them are well-commented/documented and normally kept as understandable as possible for
-	anyone to pick them and modify/patch them as they wish.
-	I have no business in keeping anything obfuscated and blind. My main thoughts are that everyone
-	has to start somewhere and understanding other code is one way to do so. With this, I aim to
-	keep those different scripts as light as possible.
-
-	Moreover, all of my scripts are totally free to use, modify, etc. as they are under the BSD-3-Clause
-	license. I just ask for you to try to keep the same scope as me and if possible, a little credit is
-	always appreciated ;)
-	Also, feel free to make a pull request! I will be more than happy to see what are your QOL too!
-
-	However, everyone has his/her/its/their own way to code and mine is mine, so if you were not able
-	to understand something, please feel free to ask me on Discord.
-
-	This is my structure:
-	- 'Globales' are var used everywhere in this js and do not need to be re-made each time
-	- 'Classes' are either specific or custom classes used for scripts
-	- 'Handlers' are scripts that handle (or hook) specific events
-	- 'Functions' are functions either called by handlers or anywhere else, they hold most of my scripts
-	- 'Utilities' are scripts to do small calculation across other functions
-
-	Cheers,
-	Nice to see you (NiceTSY)
-*/
-
-'use strict';
-
 import { Logging } from "./logging.js";
 
 /*------------------------------------------------------------------------------------------------
@@ -117,6 +85,7 @@ export class Utils {
 		}
 
 		return {
+			source: matchResult[0],
 			id: matchResult[1],
 			name: matchResult[2],
 		};

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -95,10 +95,16 @@ export class Utils {
 	 *
 	 * @param {Item} item
 	 * @param {Array} types
-	 * @returns
+	 * @param {function} callback
+	 * @returns {Boolean}
 	 */
-	static shouldStackItem(item, types) {
-		Logging.debug('Utils.shouldStackItem', item, types);
+	static shouldStackItem(item, types, callback) {
+		Logging.debug('Utils.shouldStackItem', item, types, callback);
+
+		if(callback) {
+			Logging.debug("Using stacked item callback");
+			return callback(item);
+		}
 
 		const itemType = item.type.toLowerCase();
 		const itemSubtype = item.system.subtype?.toLowerCase() || null;


### PR DESCRIPTION
Items are specified by a link (to get full item info) or by a text label. All other information is handled using modifiers (q=, etc.). "Type" can be coerced using the `t` modifier. Adds a `s` (stacked) modifier to coerce stacking behavior when adding an already present item.

Rationale:
* Addresses the weird issue of how currency is handled in PF2 and some other systems.
* Encourages use of links instead of text as the default parcel entry data.
* Remove potential confusion about which directive to use for which type of item and possiblity of choosing the "wrong" one.